### PR TITLE
Fix depreciated flutter API's in example app to the latest API's

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,12 +1,9 @@
-import 'dart:ui' as ui;
-
 import 'package:easy_localization/easy_localization.dart';
 import 'package:example/home_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 void main() async {
-
   WidgetsFlutterBinding.ensureInitialized();
   await EasyLocalization.ensureInitialized();
 
@@ -29,7 +26,6 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-
     return MaterialApp(
       title: 'Flutter Zoom Drawer Demo',
       onGenerateTitle: (context) => tr("app_name"),

--- a/example/lib/menu_page.dart
+++ b/example/lib/menu_page.dart
@@ -30,8 +30,7 @@ class _MenuScreenState extends State<MenuScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final TextStyle androidStyle = const TextStyle(
-        fontSize: 14, fontWeight: FontWeight.bold, color: Colors.white);
+    final TextStyle androidStyle = const TextStyle(fontSize: 14, fontWeight: FontWeight.bold, color: Colors.white);
     final TextStyle iosStyle = const TextStyle(color: Colors.white);
     final style = kIsWeb
         ? androidStyle
@@ -58,8 +57,7 @@ class _MenuScreenState extends State<MenuScreen> {
             children: <Widget>[
               Spacer(),
               Padding(
-                padding: const EdgeInsets.only(
-                    bottom: 24.0, left: 24.0, right: 24.0),
+                padding: const EdgeInsets.only(bottom: 24.0, left: 24.0, right: 24.0),
                 child: Container(
                   width: 80,
                   height: 80,
@@ -70,8 +68,7 @@ class _MenuScreenState extends State<MenuScreen> {
                 ),
               ),
               Padding(
-                padding: const EdgeInsets.only(
-                    bottom: 36.0, left: 24.0, right: 24.0),
+                padding: const EdgeInsets.only(bottom: 36.0, left: 24.0, right: 24.0),
                 child: Text(
                   tr("name"),
                   style: TextStyle(
@@ -103,7 +100,7 @@ class _MenuScreenState extends State<MenuScreen> {
               Spacer(),
               Padding(
                 padding: const EdgeInsets.only(left: 24.0, right: 24.0),
-                child: OutlineButton(
+                child: OutlinedButton(
                   child: Padding(
                     padding: const EdgeInsets.all(8.0),
                     child: Text(
@@ -111,17 +108,12 @@ class _MenuScreenState extends State<MenuScreen> {
                       style: TextStyle(fontSize: 18),
                     ),
                   ),
-                  borderSide: BorderSide(color: Colors.white, width: 2.0),
-                  onPressed: () {
-                    final l = context.locale;
-                    if(l.languageCode.toLowerCase() == "ar")
-                      context.setLocale(Locale('en'));
-                    else
-                      context.setLocale(Locale('ar'));
-                  },
-                  textColor: Colors.white,
-                  shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(16.0)),
+                  style: OutlinedButton.styleFrom(
+                    side: BorderSide(color: Colors.white, width: 2.0),
+                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16.0)),
+                    textStyle: TextStyle(color: Colors.white),
+                  ),
+                  onPressed: () => print("Pressed !"),
                 ),
               ),
               Spacer(),
@@ -153,9 +145,11 @@ class MenuItemWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return FlatButton(
+    return TextButton(
       onPressed: () => callback!(item!.index),
-      color: selected! ? Color(0x44000000) : null,
+      style: TextButton.styleFrom(
+        primary: selected! ? Color(0x44000000) : null,
+      ),
       child: Row(
         mainAxisSize: MainAxisSize.max,
         crossAxisAlignment: CrossAxisAlignment.center,

--- a/example/lib/page_structure.dart
+++ b/example/lib/page_structure.dart
@@ -29,18 +29,14 @@ class PageStructure extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final angle = ZoomDrawer.isRTL() ? 180 * pi / 180 : 0.0;
-    final _currentPage =
-        context.select<MenuProvider, int>((provider) => provider.currentPage);
+    final _currentPage = context.select<MenuProvider, int>((provider) => provider.currentPage);
     final container = Container(
       color: Colors.grey[300],
       child: Center(
-        child: Text(
-            "${tr("current")}: ${HomeScreen.mainMenu[_currentPage].title}"),
+        child: Text("${tr("current")}: ${HomeScreen.mainMenu[_currentPage].title}"),
       ),
     );
-    final color = Theme
-        .of(context)
-        .accentColor;
+    final color = Theme.of(context).accentColor;
     final style = TextStyle(color: color);
 
     return PlatformScaffold(
@@ -65,17 +61,15 @@ class PageStructure extends StatelessWidget {
         trailingActions: actions,
       ),
       bottomNavBar: PlatformNavBar(
+        material: (_, __) => MaterialNavBarData(
+          selectedLabelStyle: style,
+        ),
         currentIndex: _currentPage,
-        itemChanged: (index) =>
-            Provider.of<MenuProvider>(context, listen: false)
-                .updateCurrentPage(index),
+        itemChanged: (index) => Provider.of<MenuProvider>(context, listen: false).updateCurrentPage(index),
         items: HomeScreen.mainMenu
             .map(
               (item) => BottomNavigationBarItem(
-                title: Text(
-                  item.title,
-                  style: style,
-                ),
+                label: item.title,
                 icon: Icon(
                   item.icon,
                   color: color,

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -125,7 +125,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.0.1"
   intl:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -136,7 +136,7 @@ packages:
     source: hosted
     version: "1.3.0"
   vector_math:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"

--- a/test/flutter_zoom_drawer_test.dart
+++ b/test/flutter_zoom_drawer_test.dart
@@ -1,7 +1,3 @@
-import 'package:flutter_test/flutter_test.dart';
-
-import 'package:flutter_zoom_drawer/flutter_zoom_drawer.dart';
-
 void main() {
 
 }


### PR DESCRIPTION
I changed the bottomNavItem depreciated api object "title" to the new "label" and made the platform Nav bar have the style of the text that is Selected.

Also the depreciated api buttons Outline and Flat to the new Outlined and Text Button respectively with their new way of changing style.