### PR TITLE
Added overlayColor, overlayBlend, mainScreenTapClose and boxShadow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# [2.2.0]
+
+* Added overlayColor, overlayBlend, mainScreenTapClose and boxShadow
+* Restructured mainScreen effects stack, cleaned up bugs, added Style8 from a fork
+
 # [2.1.2]
 
 * fixed swipe to close issue

--- a/example/lib/home_screen.dart
+++ b/example/lib/home_screen.dart
@@ -44,6 +44,10 @@ class _HomeScreenState extends State<HomeScreen> {
       swipeOffset: 2.0,
       slideWidth: MediaQuery.of(context).size.width * (isRtl ? .55 : 0.65),
       isRtl: isRtl,
+      mainScreenTapClose: true,
+      overlayColor: Colors.brown.withOpacity(0.5),
+      overlayBlend: BlendMode.darken,
+      boxShadow: [BoxShadow(color: Colors.black87, blurRadius: 12)],
     );
   }
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -125,7 +125,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.1.1"
+    version: "2.2.0"
   intl:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,14 +21,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -66,14 +66,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
@@ -127,7 +127,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.3"
   typed_data:
     dependency: transitive
     description:
@@ -141,6 +141,6 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_zoom_drawer
 description: A Flutter package with custom implementation of the Side Menu (Drawer)
-version: 2.1.2
+version: 2.2.0
 homepage: https://github.com/medyas/flutter_zoom_drawer
 
 environment:


### PR DESCRIPTION
I liked this drawer, except it was missing basic features I had in my previous side menu drawer I was used to.  Looks much better now with a customizable shadow and an overlay blend that animates in, and needed the ability to close menu when tapping main screen.  I also restructured mainScreen effects stack and cleaned up little bugs. Much more usable now, I like the way it came out in my app. May be worth adding more customizations in there later too..  Here's the summary of additions:
```dart
  /// Color of the main screen's cover overlay
  final Color? overlayColor;
  /// The BlendMode of the [overlayColor] filter (default BlendMode.screen)
  final BlendMode? overlayBlend;
  /// The Shadow of the mainScreenContent
  final List<BoxShadow>? boxShadow;
  /// Close drawer when tapping mainScreen
  final bool mainScreenTapClose;
```
I hope I didn't step on any toes bumping version to 2.2.0 and pretty much depreciated [showShadow] and [clipMainScreen].  Made the changes for myself, but worth sharing the upgrade.  Thanks for the addon..