### PR TITLE
Added overlayBlur, shrinkMainScreen & drawerStyleBuilder, fixed angle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# [2.2.3]
+
+* Added `overlayBlur`, `shrinkMainScreen` and `drawerStyleBuilder`
+* Fixed `angle` to rotate all styles, not just Style1
+
 # [2.2.2+1]
 
 * Fixed `Style1` state
@@ -14,7 +19,7 @@
 
 # [2.2.0]
 **Thanks to @Skquark for his contribution**
-* Added overlayColor, overlayBlend, mainScreenTapClose and boxShadow
+* Added `overlayColor`, `overlayBlend`, `mainScreenTapClose` and `boxShadow`
 * Restructured mainScreen effects stack, cleaned up bugs, added Style8 from a fork
 
 # [2.1.2]

--- a/README.md
+++ b/README.md
@@ -139,7 +139,13 @@ class MyDrawerController extends GetxController {
 | `isRtl`            | `bool`                 |    No     | Boolean, display the drawer in RTL             |
 | `openCurve`        | `Curve`                |    No     | open animation curve - defaults to `Curves.easeOut`                         |
 | `closeCurve`       | `Curve`                |    No     | close animation curve - defaults to `Curves.easeOut`                        |
-
+| `mainScreenTapClose` | `bool`               |    No     | Close drawer when tapping mainScreen             |
+| `overlayColor`     | `Color`                |    No     | Color of the main screen's cover overlay                  |
+| `overlayBlend`     | `BlendMode`            |    No     | The BlendMode of the `overlayColor` filter (default BlendMode.screen)      |
+| `boxShadow`        | `BoxShadow`            |    No     | The Shadow of the mainScreenContent                        |
+| `overlayBlur`      | `double`               |    No     | The Blur amount of the mainScreen option             |
+| `shrinkMainScreen` | `bool`                 |    No     | Shrinks the mainScreen by [slideWidth], good on desktop with Style2         |
+| `drawerStyleBuilder`| `DrawerStyleBuilder`  |    No     | Build custom animated style to override [DrawerStyle]             |
 
 ### Controlling the drawer
 

--- a/lib/flutter_zoom_drawer.dart
+++ b/lib/flutter_zoom_drawer.dart
@@ -334,6 +334,7 @@ class _ZoomDrawerState extends State<ZoomDrawer>
 
   /// Builds the layers of decorations on mainScreen
   Widget get mainScreenContent {
+    if (_percentOpen == 0) return widget.mainScreen;
     Widget _mainScreenContent = widget.mainScreen;
     if (widget.shrinkMainScreen) {
       var mainSize = MediaQuery.of(context).size.width - (widget.slideWidth * _percentOpen);
@@ -451,6 +452,7 @@ class _ZoomDrawerState extends State<ZoomDrawer>
       },
     );
   }
+  
   Widget renderDefault() {
     return AnimatedBuilder(
       animation: _animationController!,


### PR DESCRIPTION
Couldn't resist adding these extra features to the drawer, adds that extra cool factor.  I wanted to slightly blur the contents of mainScreen and while trying to make my app responsive for web/desktop I wanted an always open menu to take the extra width, but had to shrink the mainScreen width to do it.  Also added a Builder for people to make their own custom style tweaks if they want even fancier than the presets.  Also wanted to apply the angle to all styles, it's there so might as well tilt a couple degrees, so I fixed that.  That fix might affect people already using it without setting angle: 0 if they didn't want it, default is still -12 degrees.  All good, feels more complete now...