### PR TITLE
Fixed mainScreenTapClose is opening instead of closing, removed unuse…

### DIFF
--- a/example/lib/home_screen.dart
+++ b/example/lib/home_screen.dart
@@ -1,7 +1,6 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:example/menu_page.dart';
 import 'package:example/page_structure.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_zoom_drawer/flutter_zoom_drawer.dart';
 import 'package:provider/provider.dart';

--- a/example/lib/menu_page.dart
+++ b/example/lib/menu_page.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 
 import 'package:easy_localization/easy_localization.dart';
 import 'package:example/home_screen.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';

--- a/example/lib/page_structure.dart
+++ b/example/lib/page_structure.dart
@@ -3,7 +3,6 @@ import 'dart:math' show pi;
 
 import 'package:easy_localization/easy_localization.dart';
 import 'package:example/home_screen.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
@@ -28,7 +27,7 @@ class PageStructure extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final color = Theme.of(context).accentColor;
+    final color = Theme.of(context).colorScheme.secondary;
     final angle = context.locale.languageCode == "ar" ? 180 * pi / 180 : 0.0;
     final _currentPage =
         context.select<MenuProvider, int>((provider) => provider.currentPage);
@@ -65,26 +64,28 @@ class PageStructure extends StatelessWidget {
           selectedLabelStyle: TextStyle(color: color),
         ),
         currentIndex: _currentPage,
-        itemChanged: (index) => Provider.of<MenuProvider>(context, listen: false).updateCurrentPage(index),
+        itemChanged: (index) =>
+            Provider.of<MenuProvider>(context, listen: false)
+                .updateCurrentPage(index),
         items: HomeScreen.mainMenu
             .map(
               (item) => BottomNavigationBarItem(
-            label: item.title,
-            icon: Icon(
-              item.icon,
-              color: color,
-            ),
-          ),
-        )
+                label: item.title,
+                icon: Icon(
+                  item.icon,
+                  color: color,
+                ),
+              ),
+            )
             .toList(),
       ),
       body: kIsWeb
           ? container
           : Platform.isAndroid
-          ? container
-          : SafeArea(
-        child: container,
-      ),
+              ? container
+              : SafeArea(
+                  child: container,
+                ),
     );
   }
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -125,7 +125,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.3.0"
+    version: "2.3.1+1"
   intl:
     dependency: transitive
     description:

--- a/lib/flutter_zoom_drawer.dart
+++ b/lib/flutter_zoom_drawer.dart
@@ -416,9 +416,10 @@ class _ZoomDrawerState extends State<ZoomDrawer>
           toggle();
         }
       },
-      onTap: (widget.mainScreenTapClose && _state == DrawerState.open)
-          ? () => close()
-          : null,
+      onTap: () {
+        if (widget.mainScreenTapClose && _state == DrawerState.open)
+          return close();
+      },
       child: renderLayout(),
     );
   }

--- a/lib/flutter_zoom_drawer.dart
+++ b/lib/flutter_zoom_drawer.dart
@@ -2,6 +2,7 @@ library flutter_zoom_drawer;
 
 import 'dart:math' show pi;
 import 'dart:ui';
+
 import 'package:flutter/material.dart';
 
 class ZoomDrawerController {
@@ -415,8 +416,9 @@ class _ZoomDrawerState extends State<ZoomDrawer>
           toggle();
         }
       },
-      onTap: (widget.mainScreenTapClose && _state == DrawerState.open)? 
-        () => toggle(): null,
+      onTap: (widget.mainScreenTapClose && _state == DrawerState.open)
+          ? () => close()
+          : null,
       child: renderLayout(),
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -67,6 +67,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -127,7 +134,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.8"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
While mainScreenTapClose is true, Clicking on any widget that has GestureDetector in mainScreen right after the drawer being closed will cause the drawer to re-open due to its being toggled instead of Close.

Please see [lib/flutter_zoom_drawer.dart](https://github.com/medyas/flutter_zoom_drawer/compare/master...YDA93:master#diff-4272334eb1d9d1beebd961ed39b3f5d5e8ad3ad43afbc34e2110ddc242df70d7)

