### PR TITLE
Fixed `androidCloseOnBackTap`

### DIFF
--- a/lib/flutter_zoom_drawer.dart
+++ b/lib/flutter_zoom_drawer.dart
@@ -749,8 +749,9 @@ class _ZoomDrawerState extends State<ZoomDrawer>
           if ([DrawerState.open, DrawerState.opening]
               .contains(stateNotifier.value)) {
             close();
+            return false;
           }
-          return false;
+          return true;
         },
         child: _parentWidget,
       );


### PR DESCRIPTION
If the drawer is already closed, it must allow for a successful pop to the previous route.