### PR TITLE
Add web support

### DIFF
--- a/lib/src/flutter_zoom_drawer.dart
+++ b/lib/src/flutter_zoom_drawer.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'dart:math' show pi;
 import 'dart:ui';
 
@@ -819,12 +818,10 @@ class ZoomDrawerState extends State<ZoomDrawer>
     }
 
     // Add layer - WillPopScope
-    if (!kIsWeb && Platform.isAndroid && widget.androidCloseOnBackTap) {
+    if (!kIsWeb && defaultTargetPlatform == TargetPlatform.android && widget.androidCloseOnBackTap) {
       parentWidget = WillPopScope(
         onWillPop: () async {
-          // Case drawer is opened or will open, either way will close
-          if ([DrawerState.open, DrawerState.opening]
-              .contains(stateNotifier.value)) {
+          if ([DrawerState.open, DrawerState.opening].contains(stateNotifier.value)) {
             close();
             return false;
           }


### PR DESCRIPTION
In Flutter Web, the use of dart:io, which is not allowed, has led to the absence of a web support indication on pub.dev. This has caused a misunderstanding among most people, including myself, that this plugin does not support the web. Therefore, I removed dart:io and replaced the necessary functions with other features that support the web.

<img width="676" alt="스크린샷 2024-02-26 오전 10 07 43" src="https://github.com/medyas/flutter_zoom_drawer/assets/21379657/966b9776-3805-4cff-b646-c203e1a82eda">
