### PR TITLE
added onAnimationValueChange (#138)

### DIFF
--- a/lib/src/flutter_zoom_drawer.dart
+++ b/lib/src/flutter_zoom_drawer.dart
@@ -55,6 +55,7 @@ class ZoomDrawer extends StatefulWidget {
     this.shrinkMainScreen = false,
     this.boxShadow,
     this.drawerStyleBuilder,
+    this.onAnimationValueChange,
   });
 
   /// Layout style
@@ -186,6 +187,9 @@ class ZoomDrawer extends StatefulWidget {
   /// ```
   final DrawerStyleBuilder? drawerStyleBuilder;
 
+  /// Listen to the change of animation value
+  final void Function(double value)? onAnimationValueChange;
+
   @override
   ZoomDrawerState createState() => ZoomDrawerState();
 
@@ -216,7 +220,9 @@ class ZoomDrawerState extends State<ZoomDrawer>
     vsync: this,
     duration: widget.duration,
     reverseDuration: widget.duration,
-  )..addStatusListener(_animationStatusListener);
+  )
+    ..addStatusListener(_animationStatusListener)
+    ..addListener(() => widget.onAnimationValueChange?.call(_animationValue));
 
   double get _animationValue => _animationController.value;
 


### PR DESCRIPTION
By using onAnimationValueChange to listen the change of animation value, we can associate ZoomDrawer with other animation widgets. For example:
```
final ac = AnimationController(vsync: this, duration: const Duration(milliseconds: 0))
    ..animateTo(1.0, duration: const Duration(milliseconds: 0));
```
```
ZoomDrawer(..., 
  onAnimationValueChange: (value) => ac.animateTo(1 - value),
);
```
```
AnimatedIcon(icon: AnimatedIcons.arrow_menu, progress: ac);
```
So when opening or closing ZoomDrawer, our AnimatedIcon will animate to the corresponding position.