### PR TITLE
Make yPosition not depend on _slideDirection

### DIFF
--- a/lib/src/flutter_zoom_drawer.dart
+++ b/lib/src/flutter_zoom_drawer.dart
@@ -503,8 +503,7 @@ class ZoomDrawerState extends State<ZoomDrawer>
 
     /// Sliding Y
     final yPosition =
-        ((widget.slideHeight - slide) * _animationValue * _slideDirection) *
-            slidePercent;
+        ((widget.slideHeight - slide) * _animationValue) * slidePercent;
 
     /// Scale
     final scalePercentage = scale - (widget.mainScreenScale * scalePercent);


### PR DESCRIPTION
The `yPosition` must not depend on  `_slideDiirection`.

It should only affect on the `xPosition`.

# English version
![Simulator Screenshot - iPhone 15 Pro Max - 2024-04-08 at 12 06 28](https://github.com/medyas/flutter_zoom_drawer/assets/30933932/8b1cc7c0-a68a-4012-b32b-c996b66a6a5c)

# Arabic version (Expected)
![simulator_screenshot_D794C85A-3E92-472E-BA56-36BED4D62789](https://github.com/medyas/flutter_zoom_drawer/assets/30933932/c6745e9b-83f1-4c5f-af8e-131b04c3fbe6)

# Arabic version (Actual)
![Simulator Screenshot - iPhone 15 Pro Max - 2024-04-08 at 12 06 22](https://github.com/medyas/flutter_zoom_drawer/assets/30933932/a683a22a-7135-4d03-8f1c-eb8b4395ef7f)